### PR TITLE
ATLDEV-278 Fix NullPointerException when deleting user

### DIFF
--- a/src/main/java/org/catrobat/jira/timesheet/rest/UserRest.java
+++ b/src/main/java/org/catrobat/jira/timesheet/rest/UserRest.java
@@ -215,10 +215,12 @@ public class UserRest {
     	if (currentTimesheetID != null && !currentTimesheetID.equals("undefined")) {
     		int currentTimesheetIDint = Integer.parseInt(currentTimesheetID);
     		Timesheet currentTimesheet = timesheetService.getTimesheetByID(currentTimesheetIDint);
-        	String currentUserKey = currentTimesheet.getUserKey();
-        	LOGGER.trace("currentUserKey: " + currentUserKey);
-        	user = ComponentAccessor.getUserManager().getUserByKey(currentUserKey);
-        	LOGGER.debug("with ID > USER FOR COORD TEAM INFO VIEW IS: " + user.getDisplayName());		
+            if (currentTimesheet != null) {
+                String currentUserKey = currentTimesheet.getUserKey();
+                LOGGER.trace("currentUserKey: " + currentUserKey);
+                user = ComponentAccessor.getUserManager().getUserByKey(currentUserKey);
+                LOGGER.debug("with ID > USER FOR COORD TEAM INFO VIEW IS: " + user.getDisplayName());
+            }
     	}
         
         if (user == null || user.getUsername().equals("")) {

--- a/src/main/java/org/catrobat/jira/timesheet/rest/UserRest.java
+++ b/src/main/java/org/catrobat/jira/timesheet/rest/UserRest.java
@@ -25,6 +25,7 @@ import com.atlassian.jira.component.ComponentAccessor;
 import com.atlassian.jira.config.properties.APKeys;
 import com.atlassian.jira.exception.PermissionException;
 import com.atlassian.jira.plugin.webfragment.model.JiraHelper;
+import com.atlassian.jira.service.ServiceException;
 import com.atlassian.jira.user.ApplicationUser;
 import com.atlassian.jira.user.util.UserManager;
 import com.atlassian.jira.user.util.UserUtil;
@@ -138,7 +139,17 @@ public class UserRest {
         List<JsonUserInformation> jsonUserInformationList = new ArrayList<>();
         
         for (Timesheet timesheet : timesheetService.all()) {
-            
+
+            ApplicationUser u = ComponentAccessor.getUserManager().getUserByKey(timesheet.getUserKey());
+            if(u == null) {
+                try {
+                    timesheetService.remove(timesheet);
+                } catch (ServiceException e) {
+                    //ignore
+                }
+                continue;
+            }
+
         	JsonUserInformation jsonUserInformation = new JsonUserInformation(timesheet);
         	
             jsonUserInformation.setHoursPerHalfYear(timesheetEntryService.getHoursOfLastXMonths(timesheet, 6));
@@ -251,7 +262,16 @@ public class UserRest {
         List<JsonUserInformation> jsonUserInformationListForCoordinator = new ArrayList<>();
 
         for (Timesheet timesheet : timesheetService.all()) {
-            	
+
+            ApplicationUser u = ComponentAccessor.getUserManager().getUserByKey(timesheet.getUserKey());
+            if(u == null) {
+                try {
+                    timesheetService.remove(timesheet);
+                } catch (ServiceException e) {
+                    //ignore
+                }
+                continue;
+            }
         	JsonUserInformation jsonUserInformation = new JsonUserInformation(timesheet);
         	
             String userName = jsonUserInformation.getUserName();

--- a/src/main/java/org/catrobat/jira/timesheet/rest/UserRest.java
+++ b/src/main/java/org/catrobat/jira/timesheet/rest/UserRest.java
@@ -142,11 +142,6 @@ public class UserRest {
 
             ApplicationUser u = ComponentAccessor.getUserManager().getUserByKey(timesheet.getUserKey());
             if(u == null) {
-                try {
-                    timesheetService.remove(timesheet);
-                } catch (ServiceException e) {
-                    //ignore
-                }
                 continue;
             }
 
@@ -265,11 +260,6 @@ public class UserRest {
 
             ApplicationUser u = ComponentAccessor.getUserManager().getUserByKey(timesheet.getUserKey());
             if(u == null) {
-                try {
-                    timesheetService.remove(timesheet);
-                } catch (ServiceException e) {
-                    //ignore
-                }
                 continue;
             }
         	JsonUserInformation jsonUserInformation = new JsonUserInformation(timesheet);

--- a/src/test/java/ut/org/catrobat/jira/timesheet/activeobjects/MySampleDatabaseUpdater.java
+++ b/src/test/java/ut/org/catrobat/jira/timesheet/activeobjects/MySampleDatabaseUpdater.java
@@ -30,10 +30,6 @@ public class MySampleDatabaseUpdater implements DatabaseUpdater {
             new DBParam("USER_KEY", "joh")
         );
 
-        Timesheet emptySheet = em.create(Timesheet.class,
-                new DBParam("USER_KEY", "empty")
-        );
-
         Team scratchTeam = em.create(Team.class,
             new DBParam("TEAM_NAME", "SCRATCH")
         );

--- a/src/test/java/ut/org/catrobat/jira/timesheet/activeobjects/MySampleDatabaseUpdater.java
+++ b/src/test/java/ut/org/catrobat/jira/timesheet/activeobjects/MySampleDatabaseUpdater.java
@@ -30,6 +30,10 @@ public class MySampleDatabaseUpdater implements DatabaseUpdater {
             new DBParam("USER_KEY", "joh")
         );
 
+        Timesheet emptySheet = em.create(Timesheet.class,
+                new DBParam("USER_KEY", "empty")
+        );
+
         Team scratchTeam = em.create(Team.class,
             new DBParam("TEAM_NAME", "SCRATCH")
         );

--- a/src/test/java/ut/org/catrobat/jira/timesheet/rest/UserRestTest.java
+++ b/src/test/java/ut/org/catrobat/jira/timesheet/rest/UserRestTest.java
@@ -98,6 +98,7 @@ public class UserRestTest {
         ApplicationUser joh = mock(ApplicationUser.class);
         when(userManager.getUserByKey("chris")).thenReturn(chris);
         when(userManager.getUserByKey("joh")).thenReturn(joh);
+        when(userManager.getUserByKey("empty")).thenReturn(null);
         when(chris.getUsername()).thenReturn("chris");
         when(joh.getUsername()).thenReturn("joh");
         when(chris.getEmailAddress()).thenReturn("chris@example.com");

--- a/src/test/java/ut/org/catrobat/jira/timesheet/rest/UserRestTest.java
+++ b/src/test/java/ut/org/catrobat/jira/timesheet/rest/UserRestTest.java
@@ -51,6 +51,7 @@ public class UserRestTest {
     private UserUtil userUtilMock;
     private ApplicationUser userMock;
     private EntityManager entityManager;
+    private UserManager userManager;
     private PermissionService permissionServiceMock;
     private UserSearchService userSearchService;
     private GroupPickerSearchService groupPickerSearchService;
@@ -74,7 +75,7 @@ public class UserRestTest {
         TeamService teamService = mock(TeamService.class, RETURNS_DEEP_STUBS);
         userSearchService = mock(UserSearchService.class, RETURNS_DEEP_STUBS);
         groupPickerSearchService = mock(GroupPickerSearchService.class, RETURNS_DEEP_STUBS);
-        UserManager userManager = mock(UserManager.class);
+        userManager = mock(UserManager.class);
 
         UserRest userRest = new UserRest(configServiceMock, permissionServiceMock, timesheetService,
                 timesheetEntryServiceMock, teamService, userSearchService, groupPickerSearchService);
@@ -98,7 +99,6 @@ public class UserRestTest {
         ApplicationUser joh = mock(ApplicationUser.class);
         when(userManager.getUserByKey("chris")).thenReturn(chris);
         when(userManager.getUserByKey("joh")).thenReturn(joh);
-        when(userManager.getUserByKey("empty")).thenReturn(null);
         when(chris.getUsername()).thenReturn("chris");
         when(joh.getUsername()).thenReturn("joh");
         when(chris.getEmailAddress()).thenReturn("chris@example.com");
@@ -159,6 +159,27 @@ public class UserRestTest {
         assertEquals(2, ((List<Group>)response.getEntity()).size());
     }
 
+    @Test
+    public void testUserInformationForDeletedUser() {
+        when(userManager.getUserByKey("joh")).thenReturn(null);
+        when(permissionServiceMock.checkRootPermission()).thenReturn(null);
+
+        Response response = spyUserRest.getUserInformation(httpRequestMock);
+        assertEquals(1, ((List<JsonUserInformation>) response.getEntity()).size());
+    }
+
+    @Test
+    public void testUsersForCoordinatorWithDeletedUser() throws PermissionException {
+        when(userManager.getUserByKey("joh")).thenReturn(null);
+
+        when(permissionServiceMock.checkIfUserExists()).thenReturn(userMock);
+        when(permissionServiceMock.isUserTeamCoordinator(userMock)).thenReturn(true);
+        when(permissionServiceMock.isUserCoordinatorOfTimesheet(eq(userMock), any())).thenReturn(true);
+
+        Response response = spyUserRest.getUsersForCoordinator(httpRequestMock, "125");
+        assertEquals(0, ((List<JsonUserInformation>) response.getEntity()).size());
+    }
+    
     @Test
     public void testUserInformation() {
         when(permissionServiceMock.checkRootPermission()).thenReturn(null);


### PR DESCRIPTION
Fixed NullPointerException when deleting user.
If the user was deleted, then the Timesheet of this user will be deleted when accessing the User-Information page (where the NullPointerException happened).